### PR TITLE
fix: Linux libc variant (gnu/musl) - platform selection

### DIFF
--- a/cmd/ore/commands/commands_test.go
+++ b/cmd/ore/commands/commands_test.go
@@ -298,3 +298,50 @@ func TestPostInstallMessageParsing(t *testing.T) {
 		t.Errorf("expected 0 messages from empty dir, got %d", len(messages))
 	}
 }
+
+// TestPlatformMatches tests platform matching logic
+func TestPlatformMatches(t *testing.T) {
+	tests := []struct {
+		name            string
+		gemPlatform     string
+		currentPlatform string
+		want            bool
+	}{
+		// Exact matches
+		{"exact match linux-gnu", "x86_64-linux-gnu", "x86_64-linux-gnu", true},
+		{"exact match linux-musl", "x86_64-linux-musl", "x86_64-linux-musl", true},
+		{"exact match darwin", "arm64-darwin", "arm64-darwin", true},
+
+		// Linux libc variants - gnu system
+		{"gnu gem on gnu system", "x86_64-linux-gnu", "x86_64-linux-gnu", true},
+		{"musl gem on gnu system", "x86_64-linux-musl", "x86_64-linux-gnu", false},
+		{"plain linux gem on gnu system", "x86_64-linux", "x86_64-linux-gnu", true},
+
+		// Linux libc variants - musl system
+		{"gnu gem on musl system", "x86_64-linux-gnu", "x86_64-linux-musl", false},
+		{"musl gem on musl system", "x86_64-linux-musl", "x86_64-linux-musl", true},
+		{"plain linux gem on musl system", "x86_64-linux", "x86_64-linux-musl", true},
+
+		// Darwin with version suffixes
+		{"darwin versioned match", "arm64-darwin-24", "arm64-darwin", true},
+		{"darwin versioned match 2", "arm64-darwin", "arm64-darwin-24", true},
+		{"darwin versioned exact", "arm64-darwin-24", "arm64-darwin-24", true},
+
+		// Architecture mismatches
+		{"arch mismatch", "aarch64-linux-gnu", "x86_64-linux-gnu", false},
+		{"os mismatch", "x86_64-darwin", "x86_64-linux-gnu", false},
+
+		// Edge cases
+		{"too short gem platform", "linux", "x86_64-linux-gnu", false},
+		{"too short current platform", "x86_64-linux-gnu", "linux", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := platformMatches(tt.gemPlatform, tt.currentPlatform)
+			if got != tt.want {
+				t.Errorf("platformMatches(%q, %q) = %v, want %v", tt.gemPlatform, tt.currentPlatform, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ore/commands/helpers.go
+++ b/cmd/ore/commands/helpers.go
@@ -245,7 +245,8 @@ func platformMatches(gemPlatform, currentPlatform string) bool {
 
 	// Platform variants - extract base platform components
 	// Examples: arm64-darwin-24 matches arm64-darwin
-	//           x86_64-linux-gnu matches x86_64-linux
+	//           x86_64-linux-gnu matches x86_64-linux-gnu (exact)
+	//           x86_64-linux matches x86_64-linux-gnu (generic gem, specific current)
 	gemParts := strings.Split(gemPlatform, "-")
 	currentParts := strings.Split(currentPlatform, "-")
 
@@ -254,6 +255,35 @@ func platformMatches(gemPlatform, currentPlatform string) bool {
 		return false
 	}
 
-	// Match arch and os (first two components)
-	return gemParts[0] == currentParts[0] && gemParts[1] == currentParts[1]
+	// Must match arch and os (first two components)
+	if gemParts[0] != currentParts[0] || gemParts[1] != currentParts[1] {
+		return false
+	}
+
+	// Handle Linux libc variants (gnu vs musl)
+	if gemParts[1] == "linux" {
+		gemLibc := ""
+		currentLibc := ""
+
+		if len(gemParts) >= 3 {
+			gemLibc = gemParts[2]
+		}
+		if len(currentParts) >= 3 {
+			currentLibc = currentParts[2]
+		}
+
+		// If gem has a specific libc requirement, it must match the current libc
+		if gemLibc != "" && currentLibc != "" && gemLibc != currentLibc {
+			return false
+		}
+	}
+
+	// Handle Darwin version suffixes (arm64-darwin-24 matches arm64-darwin)
+	// Darwin version is numeric, libc variants are not
+	if gemParts[1] == "darwin" {
+		// Darwin versions are just fine to not match exactly
+		return true
+	}
+
+	return true
 }

--- a/cmd/ore/commands/platform.go
+++ b/cmd/ore/commands/platform.go
@@ -112,10 +112,48 @@ func detectCurrentPlatform() string {
 	case "darwin":
 		return goarch + "-darwin"
 	case "linux":
+		// Detect libc variant (glibc vs musl)
+		libc := detectLinuxLibc()
+		if libc != "" {
+			return goarch + "-linux-" + libc
+		}
 		return goarch + "-linux"
 	default:
 		return "unsupported"
 	}
+}
+
+// detectLinuxLibc detects whether the system uses glibc or musl
+func detectLinuxLibc() string {
+	// Check for musl by looking for ld-musl-* in standard locations
+	muslPaths := []string{
+		"/lib/ld-musl-x86_64.so.1",
+		"/lib/ld-musl-aarch64.so.1",
+		"/lib64/ld-musl-x86_64.so.1",
+		"/lib64/ld-musl-aarch64.so.1",
+	}
+
+	for _, path := range muslPaths {
+		if _, err := os.Stat(path); err == nil {
+			return "musl"
+		}
+	}
+
+	// Check for glibc by looking for libc.so.6 or running ldd
+	glibcPaths := []string{
+		"/lib/x86_64-linux-gnu/libc.so.6",
+		"/lib64/libc.so.6",
+		"/lib/aarch64-linux-gnu/libc.so.6",
+	}
+
+	for _, path := range glibcPaths {
+		if _, err := os.Stat(path); err == nil {
+			return "gnu"
+		}
+	}
+
+	// Default to gnu on Linux (most common)
+	return "gnu"
 }
 
 func detectCurrentRubyVersion() string {


### PR DESCRIPTION
## Problem

When a `Gemfile.lock` contains both `x86_64-linux-gnu` and `x86_64-linux-musl` platform variants of a gem, `ore install` incorrectly installs **both** variants instead of selecting only the one matching the current system's libc.

This causes:
- Wasted bandwidth downloading unnecessary gems
- Native extension build failures
- Errors like "no dynamic libraries found" or "No targets specified and no makefile found"

## Solution

This PR adds proper Linux libc variant detection and platform matching:

### Changes

1. **`cmd/ore/commands/platform.go`**
   - Added `detectLinuxLibc()` function that detects whether the system uses glibc or musl by checking for known loader paths (`/lib/ld-musl-*` for musl, `/lib/*/libc.so.6` for glibc)
   - Updated `detectCurrentPlatform()` to append the detected libc variant on Linux (e.g., `x86_64-linux-gnu` instead of just `x86_64-linux`)

2. **`cmd/ore/commands/helpers.go`**
   - Updated `platformMatches()` to properly compare libc variants on Linux
   - If a gem specifies a libc variant (e.g., `x86_64-linux-musl`), it will NOT match a system with a different libc (e.g., `x86_64-linux-gnu`)
   - Generic Linux gems (e.g., `x86_64-linux`) continue to match any libc variant

3. **`cmd/ore/commands/commands_test.go`**
   - Added comprehensive `TestPlatformMatches` tests covering:
     - Exact matches for gnu, musl, and darwin platforms
     - Cross-libc rejection (musl gem on gnu system and vice versa)
     - Generic linux gems matching both variants
     - Darwin versioned platforms
     - Architecture and OS mismatches

## Testing

```bash
cd cmd/ore/commands
go test -run TestPlatformMatches -v
```

## Before/After

**Before:**
```
$ ore install
Installing nokogiri-1.19.0-x86_64-linux-gnu...
Installing nokogiri-1.19.0-x86_64-linux-musl...  # WRONG - shouldn't install on glibc system
Error: 2 native extension(s) failed to build.
```

**After:**
```
$ ore install
Installing nokogiri-1.19.0-x86_64-linux-gnu...   # Only the correct variant
Installed 1 gem...
```

## Compatibility

- **Backward compatible**: Generic linux gems (`x86_64-linux`) still work on both glibc and musl systems
- **No API changes**: All changes are internal to platform detection logic
- **Defaults to glibc**: On Linux systems where libc cannot be detected, defaults to `gnu` (the most common case)

## Related

Fixes the platform double-install bug reported when using `ore install` with lockfiles containing both gnu and musl variants. Fixes #48 