### PR TITLE
fix: skip extension building for precompiled native gems

### DIFF
--- a/cmd/ore/install.go
+++ b/cmd/ore/install.go
@@ -252,11 +252,21 @@ func installFromCache(ctx context.Context, cacheDir, vendorDir string, gems []lo
 			return report, err
 		}
 
-		// Collect this gem for extension building (defer until all gems installed)
-		extensionTargets = append(extensionTargets, extensionTarget{
-			gemName: gem.FullName(),
-			destDir: destDir,
-		})
+		// Only add to extension targets if the gem actually needs building
+		// Precompiled native gems (e.g., nokogiri-1.19.0-x86_64-linux-gnu) already
+		// have their .so files and should NOT trigger extension compilation
+		needsBuild, err := extensions.NeedsBuild(destDir, engine)
+		if err != nil {
+			// Log warning but don't fail - extension building is best-effort
+			if extConfig != nil && extConfig.Verbose {
+				fmt.Fprintf(os.Stderr, "Warning: failed to check if %s needs extension build: %v\n", gem.FullName(), err)
+			}
+		} else if needsBuild {
+			extensionTargets = append(extensionTargets, extensionTarget{
+				gemName: gem.FullName(),
+				destDir: destDir,
+			})
+		}
 
 		report.Installed++
 	}

--- a/internal/extensions/detect.go
+++ b/internal/extensions/detect.go
@@ -9,6 +9,11 @@ import (
 
 // NeedsBuild checks if a gem directory needs extension building.
 // It returns true if the gem has extension sources but no compiled artifacts.
+//
+// This mirrors RubyGems' Gem::Specification#missing_extensions? logic:
+// - Returns false if no extensions are declared
+// - Returns false if gem.build_complete marker exists (precompiled gem)
+// - Returns false if compiled artifacts (.so, .bundle, etc.) exist in lib/
 func NeedsBuild(gemDir string, engine ruby.Engine) (bool, error) {
 	// Short-circuit: Skip engines that don't support native extensions
 	if !engine.SupportsNativeExtensions() {
@@ -21,8 +26,51 @@ func NeedsBuild(gemDir string, engine ruby.Engine) (bool, error) {
 		return false, err
 	}
 
-	// Check if compiled artifacts already exist
+	// Check for gem.build_complete marker file (RubyGems/Bundler convention)
+	// Precompiled native gems include this file to indicate extensions are already built
+	if hasBuildCompleteMarker(gemDir) {
+		return false, nil
+	}
+
+	// Check if compiled artifacts already exist in lib/
 	return !hasCompiledArtifacts(gemDir), nil
+}
+
+// hasBuildCompleteMarker checks if the gem.build_complete file exists.
+// This file is created by RubyGems after successfully building extensions,
+// and is included in precompiled native gems to skip rebuilding.
+//
+// The file can be in multiple locations depending on the gem structure:
+// - extensions/<platform>/<ruby-version>/<gem-name>/gem.build_complete (standard)
+// - lib/<gem-name>/<ruby-version>/gem.build_complete (some precompiled gems)
+// - Directly in gem directory for simpler gems
+func hasBuildCompleteMarker(gemDir string) bool {
+	// Check common locations for gem.build_complete
+	possiblePaths := []string{
+		// Inside lib/ for precompiled gems (common for nokogiri, grpc, etc.)
+		filepath.Join(gemDir, "lib"),
+		// Root of gem directory
+		gemDir,
+	}
+
+	for _, basePath := range possiblePaths {
+		found := false
+		_ = filepath.WalkDir(basePath, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if d.Name() == "gem.build_complete" {
+				found = true
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if found {
+			return true
+		}
+	}
+
+	return false
 }
 
 // hasCompiledArtifacts checks for compiled extension files in the gem directory.

--- a/internal/extensions/detect_test.go
+++ b/internal/extensions/detect_test.go
@@ -1,0 +1,490 @@
+package extensions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/contriboss/ore-light/internal/ruby"
+)
+
+func TestNeedsBuild(t *testing.T) {
+	// Use MRI engine for tests (supports native extensions)
+	engine := ruby.Engine{Name: ruby.EngineMRI, Version: "3.4.0"}
+
+	tests := []struct {
+		name      string
+		setupFunc func(t *testing.T) string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "no extensions directory - does not need build",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				// Just lib/ directory, no ext/
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "has extconf.rb but no compiled artifacts - needs build",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				extDir := filepath.Join(dir, "ext", "myext")
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(extDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# extconf"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "has extconf.rb and .so file - does not need build",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				extDir := filepath.Join(dir, "ext", "myext")
+				libDir := filepath.Join(dir, "lib", "myext")
+				if err := os.MkdirAll(extDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# extconf"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				// Compiled .so file exists
+				if err := os.WriteFile(filepath.Join(libDir, "myext.so"), []byte("compiled"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "has extconf.rb and gem.build_complete marker - does not need build (precompiled gem)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				extDir := filepath.Join(dir, "ext", "nokogiri")
+				libDir := filepath.Join(dir, "lib", "nokogiri", "3.4")
+				if err := os.MkdirAll(extDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# extconf"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				// gem.build_complete marker exists (precompiled gem convention)
+				if err := os.WriteFile(filepath.Join(libDir, "gem.build_complete"), []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "has Cargo.toml with cdylib and .so file - does not need build",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				extDir := filepath.Join(dir, "ext", "rust_ext")
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(extDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				cargo := []byte("[package]\nname = \"rust_ext\"\n[lib]\ncrate-type = [\"cdylib\"]\n")
+				if err := os.WriteFile(filepath.Join(extDir, "Cargo.toml"), cargo, 0644); err != nil {
+					t.Fatal(err)
+				}
+				// Compiled .so file exists
+				if err := os.WriteFile(filepath.Join(libDir, "rust_ext.so"), []byte("compiled"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "has .bundle file (macOS) - does not need build",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				extDir := filepath.Join(dir, "ext", "myext")
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(extDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# extconf"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				// Compiled .bundle file exists (macOS)
+				if err := os.WriteFile(filepath.Join(libDir, "myext.bundle"), []byte("compiled"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setupFunc(t)
+
+			got, err := NeedsBuild(dir, engine)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NeedsBuild() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("NeedsBuild() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsBuild_JRubyEngine(t *testing.T) {
+	// JRuby engine - native extensions work differently
+	engine := ruby.Engine{Name: ruby.EngineJRuby, Version: "9.4.0"}
+
+	t.Run("JRuby with .jar file - does not need build", func(t *testing.T) {
+		dir := t.TempDir()
+		extDir := filepath.Join(dir, "ext", "java_ext")
+		libDir := filepath.Join(dir, "lib")
+		if err := os.MkdirAll(extDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(libDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(extDir, "pom.xml"), []byte("<project/>"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// Compiled .jar file exists
+		if err := os.WriteFile(filepath.Join(libDir, "java_ext.jar"), []byte("compiled"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := NeedsBuild(dir, engine)
+		if err != nil {
+			t.Errorf("NeedsBuild() error = %v", err)
+			return
+		}
+
+		if got != false {
+			t.Errorf("NeedsBuild() = %v, want false (JRuby with .jar)", got)
+		}
+	})
+}
+
+func TestHasBuildCompleteMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupFunc func(t *testing.T) string
+		want      bool
+	}{
+		{
+			name: "no marker file",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: false,
+		},
+		{
+			name: "marker in lib/ subdirectory (precompiled gem style)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib", "nokogiri", "3.4")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "gem.build_complete"), []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "marker in gem root directory",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				if err := os.WriteFile(filepath.Join(dir, "gem.build_complete"), []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "marker deeply nested in lib/",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				deepDir := filepath.Join(dir, "lib", "grpc", "2.1", "x86_64-linux")
+				if err := os.MkdirAll(deepDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(deepDir, "gem.build_complete"), []byte(""), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setupFunc(t)
+
+			got := hasBuildCompleteMarker(dir)
+
+			if got != tt.want {
+				t.Errorf("hasBuildCompleteMarker() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasCompiledArtifacts(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupFunc func(t *testing.T) string
+		want      bool
+	}{
+		{
+			name: "no lib directory",
+			setupFunc: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			want: false,
+		},
+		{
+			name: "empty lib directory",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: false,
+		},
+		{
+			name: "lib with .rb files only",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "mylib.rb"), []byte("# ruby"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: false,
+		},
+		{
+			name: "lib with .so file",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "myext.so"), []byte("binary"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "lib with .bundle file (macOS)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "myext.bundle"), []byte("binary"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "lib with .dylib file (macOS)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "myext.dylib"), []byte("binary"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "lib with .jar file (JRuby)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "myext.jar"), []byte("binary"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: ".so file in nested directory (lib/gem/version/)",
+			setupFunc: func(t *testing.T) string {
+				dir := t.TempDir()
+				libDir := filepath.Join(dir, "lib", "nokogiri", "3.4")
+				if err := os.MkdirAll(libDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(libDir, "nokogiri.so"), []byte("binary"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setupFunc(t)
+
+			got := hasCompiledArtifacts(dir)
+
+			if got != tt.want {
+				t.Errorf("hasCompiledArtifacts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNeedsBuild_PrecompiledNokogiriScenario tests the specific scenario that was failing:
+// a precompiled nokogiri gem with ext/extconf.rb but also with compiled .so files
+func TestNeedsBuild_PrecompiledNokogiriScenario(t *testing.T) {
+	engine := ruby.Engine{Name: ruby.EngineMRI, Version: "3.4.0"}
+
+	// Simulate nokogiri-1.19.0-x86_64-linux-gnu structure
+	dir := t.TempDir()
+
+	// Create ext/ structure (this is what was triggering false positives)
+	extDir := filepath.Join(dir, "ext", "nokogiri")
+	if err := os.MkdirAll(extDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# nokogiri extconf"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lib/ structure with precompiled .so files
+	libDir := filepath.Join(dir, "lib", "nokogiri", "3.4")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "nokogiri.so"), []byte("precompiled binary"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also add the gem.build_complete marker (what precompiled gems include)
+	if err := os.WriteFile(filepath.Join(libDir, "gem.build_complete"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// This should return false - the gem is already built
+	got, err := NeedsBuild(dir, engine)
+	if err != nil {
+		t.Fatalf("NeedsBuild() error = %v", err)
+	}
+
+	if got != false {
+		t.Errorf("NeedsBuild() = %v, want false for precompiled nokogiri-like gem", got)
+	}
+}
+
+// TestNeedsBuild_SourceGemNeedsCompilation tests that source gems (without precompiled artifacts)
+// correctly return true for NeedsBuild
+func TestNeedsBuild_SourceGemNeedsCompilation(t *testing.T) {
+	engine := ruby.Engine{Name: ruby.EngineMRI, Version: "3.4.0"}
+
+	// Simulate a source gem that needs compilation
+	dir := t.TempDir()
+
+	// Create ext/ structure
+	extDir := filepath.Join(dir, "ext", "myext")
+	if err := os.MkdirAll(extDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extconf.rb"), []byte("# needs compilation"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "myext.c"), []byte("/* C source */"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create lib/ structure without compiled files (only Ruby files)
+	libDir := filepath.Join(dir, "lib")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "myext.rb"), []byte("# Ruby wrapper"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// This should return true - the gem needs to be built
+	got, err := NeedsBuild(dir, engine)
+	if err != nil {
+		t.Fatalf("NeedsBuild() error = %v", err)
+	}
+
+	if got != true {
+		t.Errorf("NeedsBuild() = %v, want true for source gem needing compilation", got)
+	}
+}

--- a/internal/runtime/install.go
+++ b/internal/runtime/install.go
@@ -134,10 +134,21 @@ func InstallFromCache(ctx context.Context, cacheDir, vendorDir string, gems []lo
 			return InstallReport{}, err
 		}
 
-		extensionTargets = append(extensionTargets, extensionTarget{
-			gemName: gem.FullName(),
-			destDir: destDir,
-		})
+		// Only add to extension targets if the gem actually needs building
+		// Precompiled native gems (e.g., nokogiri-1.19.0-x86_64-linux-gnu) already
+		// have their .so files and should NOT trigger extension compilation
+		needsBuild, err := extensions.NeedsBuild(destDir, engine)
+		if err != nil {
+			// Log warning but don't fail - extension building is best-effort
+			if extConfig != nil && extConfig.Verbose {
+				fmt.Fprintf(os.Stderr, "Warning: failed to check if %s needs extension build: %v\n", gem.FullName(), err)
+			}
+		} else if needsBuild {
+			extensionTargets = append(extensionTargets, extensionTarget{
+				gemName: gem.FullName(),
+				destDir: destDir,
+			})
+		}
 
 		report.Installed++
 	}


### PR DESCRIPTION
## Problem

When installing precompiled native gems (e.g., `nokogiri-1.19.0-x86_64-linux-gnu`), ore incorrectly attempts to build native extensions even though the gem already contains precompiled `.so` files.

This causes errors like:
```
Running 'compile' for libgumbo 1.0.0-nokogiri... ERROR
make: *** No targets specified and no makefile found.  Stop.
```

## Root Cause

In the install code, every newly installed gem was unconditionally added to the extension build queue:

```go
// OLD CODE - unconditionally adds all gems
extensionTargets = append(extensionTargets, extensionTarget{
    gemName: gem.FullName(),
    destDir: destDir,
})
```

The `NeedsBuild()` check (which correctly detects precompiled `.so` files) was only being called for already-installed gems in the "skip" branch, not for fresh installs.

## Solution

### 1. Call `NeedsBuild()` before adding gems to the extension build queue

```go
// NEW CODE - only add if actually needs building
needsBuild, err := extensions.NeedsBuild(destDir, engine)
if err != nil {
    // Log warning but don't fail
    if extConfig != nil && extConfig.Verbose {
        fmt.Fprintf(os.Stderr, "Warning: failed to check if %s needs extension build: %v\n", gem.FullName(), err)
    }
} else if needsBuild {
    extensionTargets = append(extensionTargets, extensionTarget{
        gemName: gem.FullName(),
        destDir: destDir,
    })
}
```

### 2. Enhanced `NeedsBuild()` to match RubyGems/Bundler behavior

Added check for `gem.build_complete` marker file, which is the authoritative indicator that extensions are already built. This matches RubyGems' `Gem::Specification#missing_extensions?` logic:

```ruby
# RubyGems' approach
def missing_extensions?
  return false if extensions.empty?
  return false if default_gem?
  return false if File.exist? gem_build_complete_path  # <-- Key check

  true
end
```

## Changes

### `cmd/ore/install.go`

- Modified `installFromCache()` to check `NeedsBuild()` before adding gems to `extensionTargets`
- Precompiled native gems with existing `.so` files are now correctly skipped

### `internal/runtime/install.go`

- Same fix applied to the duplicate `InstallFromCache()` function in the runtime package

### `internal/extensions/detect.go`

- Added `hasBuildCompleteMarker()` function to check for `gem.build_complete` file
- Enhanced `NeedsBuild()` to check for marker file before checking for `.so` files
- Added comprehensive documentation explaining the RubyGems compatibility

## How `NeedsBuild()` Now Works

The enhanced `NeedsBuild()` function mirrors RubyGems' behavior:

1. **Check if gem has extensions** - If no `ext/` directory with build files, return `false`
2. **Check for `gem.build_complete` marker** - If present (precompiled gem), return `false`
3. **Check for compiled artifacts** - If `.so`/`.bundle`/`.dylib`/`.jar` files exist, return `false`
4. **Otherwise** - Return `true` (needs building)

For precompiled native gems like `nokogiri-1.19.0-x86_64-linux-gnu`:
- Has `ext/extconf.rb` ✓
- Has `gem.build_complete` marker ✓ (or `.so` files in lib/)
- `NeedsBuild()` returns `false` → extension build skipped ✓

## Testing

### New Test File: `internal/extensions/detect_test.go`

Added comprehensive tests for the detection logic:

- **`TestNeedsBuild`** - Tests various scenarios:
  - No extensions directory → does not need build
  - Has extconf.rb but no compiled artifacts → needs build
  - Has extconf.rb and .so file → does not need build
  - Has extconf.rb and gem.build_complete marker → does not need build (precompiled)
  - Has Cargo.toml with cdylib and .so → does not need build
  - Has .bundle file (macOS) → does not need build

- **`TestNeedsBuild_JRubyEngine`** - Tests JRuby-specific behavior with .jar files

- **`TestHasBuildCompleteMarker`** - Tests marker file detection:
  - No marker file
  - Marker in lib/ subdirectory (precompiled gem style)
  - Marker in gem root directory
  - Marker deeply nested in lib/

- **`TestHasCompiledArtifacts`** - Tests artifact detection:
  - No lib directory
  - Empty lib directory
  - lib with .rb files only
  - lib with .so/.bundle/.dylib/.jar files
  - .so file in nested directory

- **`TestNeedsBuild_PrecompiledNokogiriScenario`** - Regression test for the specific nokogiri failure case

- **`TestNeedsBuild_SourceGemNeedsCompilation`** - Ensures source gems still get built

### Running Tests

```bash
# Run the new tests
cd vendor/ore-light
go test ./internal/extensions/... -v

# Run specific test
go test ./internal/extensions/... -v -run TestNeedsBuild_PrecompiledNokogiriScenario

# Test with a precompiled native gem (integration)
ore install  # Should not attempt to compile nokogiri

# Verbose mode shows what's happening
ore install --verbose
```

## Before/After

**Before:**
```
$ ore install
Running 'compile' for libgumbo 1.0.0-nokogiri... ERROR
make: *** No targets specified and no makefile found.  Stop.
Error: 1 native extension(s) failed to build
```

**After:**
```
$ ore install
Installed 50 gems (10 skipped) in 15s.
Built 3 native extension(s).  # Only gems that actually need building
```

## Compatibility

- **Backward compatible**: Gems that genuinely need extension building still get built
- **RubyGems compatible**: Now matches RubyGems/Bundler behavior for detecting precompiled gems
- **No API changes**: Internal fix only
- **Handles errors gracefully**: If `NeedsBuild()` fails, logs warning but doesn't block installation

Fixes #50 