### PR TITLE
feat: ⬆️ Consistent support for `-gemfile` (and `-lockfile`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+* Support `-gemfile` (and `-lockfile` where applicable) flag across all relevant commands: `install`, `add`, `remove`, `update`, `lock`, `check`, `outdated`, `exec`, `audit`, `tree`, `clean`, `show`, and `platform`.
 * ⬆️ Upgrade to gemfile-go v0.10.0 w/ single group/platform support ([77f7c9f](https://github.com/contriboss/ore-light/commit/77f7c9f29ce5c9a790edf6e1d338116be6d53081))
 * ⬆️ Upgrade to gemfile-go v0.10.0 w/ single group/platform support ([3bbdd6e](https://github.com/contriboss/ore-light/commit/3bbdd6ea62fbce0a30edd446198f7699c4405916))
 

--- a/cmd/ore/commands/add.go
+++ b/cmd/ore/commands/add.go
@@ -12,6 +12,7 @@ import (
 // RunAdd implements the ore add command
 func RunAdd(args []string) error {
 	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	version := fs.String("version", "", "Version constraint (e.g., ~> 8.0)")
 	group := fs.String("group", "", "Group to add gem to")
 	github := fs.String("github", "", "GitHub repository (user/repo)")
@@ -34,13 +35,19 @@ func RunAdd(args []string) error {
 	}
 
 	// Find Gemfile
-	paths, err := lockfile.FindGemfiles()
-	if err != nil {
-		return fmt.Errorf("failed to find Gemfile: %w", err)
+	var gemfileToUse string
+	if *gemfilePath != "" {
+		gemfileToUse = *gemfilePath
+	} else {
+		paths, err := lockfile.FindGemfiles()
+		if err != nil {
+			return fmt.Errorf("failed to find Gemfile: %w", err)
+		}
+		gemfileToUse = paths.Gemfile
 	}
 
 	if *verbose {
-		fmt.Printf("📝 Adding gems to %s...\n", paths.GetGemfileName())
+		fmt.Printf("📝 Adding gems to %s...\n", gemfileToUse)
 	}
 
 	// Process each gem
@@ -93,7 +100,7 @@ func RunAdd(args []string) error {
 		}
 
 		// Add gem to Gemfile using gemfile-go writer
-		if err := gemfile.AddGemToFile(paths.Gemfile, &dep); err != nil {
+		if err := gemfile.AddGemToFile(gemfileToUse, &dep); err != nil {
 			return fmt.Errorf("failed to add gem %s: %w", gemName, err)
 		}
 
@@ -109,7 +116,7 @@ func RunAdd(args []string) error {
 		if *verbose {
 			fmt.Println("🔒 Resolving dependencies and updating lockfile...")
 		}
-		if err := resolver.GenerateLockfile(paths.Gemfile); err != nil {
+		if err := resolver.GenerateLockfile(gemfileToUse); err != nil {
 			return fmt.Errorf("failed to generate lockfile: %w", err)
 		}
 		fmt.Println("💡 Run 'ore install' to fetch the new gems")

--- a/cmd/ore/commands/audit.go
+++ b/cmd/ore/commands/audit.go
@@ -19,13 +19,25 @@ func RunAudit(args []string) error {
 	}
 
 	fs := flag.NewFlagSet("audit", flag.ContinueOnError)
-	lockfilePath := fs.String("lockfile", defaultLockfilePath(), "Path to Gemfile.lock")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	// Load lockfile
-	parsed, err := loadLockfile(*lockfilePath)
+	parsed, err := loadLockfile(effectiveLockfilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/ore/commands/check.go
+++ b/cmd/ore/commands/check.go
@@ -12,21 +12,38 @@ import (
 // RunCheck implements the ore check command
 func RunCheck(args []string) error {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	vendorDir := fs.String("vendor", defaultVendorDir(), "Vendor directory to check")
 	verbose := fs.Bool("v", false, "Enable verbose output")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(*gemfilePath)
+	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
 	if err != nil {
-		return fmt.Errorf("failed to find lockfile: %w - run 'ore lock' first", err)
+		// If findLockfilePath fails, try to use effectiveLockfilePath directly if it exists
+		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
+			finalLockfilePath = effectiveLockfilePath
+		} else {
+			return fmt.Errorf("failed to find lockfile: %w - run 'ore lock' first", err)
+		}
 	}
 
 	// Parse lockfile
-	lock, err := lockfile.ParseFile(lockfilePath)
+	lock, err := lockfile.ParseFile(finalLockfilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse lockfile: %w", err)
 	}
@@ -108,8 +125,7 @@ func RunCheck(args []string) error {
 
 		// Enhanced debugging for CI failures
 		fmt.Printf("\nDebug Information:\n")
-		fmt.Printf("  Gemfile: %s\n", *gemfilePath)
-		fmt.Printf("  Lockfile: %s\n", lockfilePath)
+		fmt.Printf("  Lockfile: %s\n", finalLockfilePath)
 		fmt.Printf("  Vendor directory: %s\n", *vendorDir)
 		fmt.Printf("  Gems directory: %s\n", gemsDir)
 

--- a/cmd/ore/commands/check_gemhome_test.go
+++ b/cmd/ore/commands/check_gemhome_test.go
@@ -30,12 +30,12 @@ gem 'rake'
 	oldBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if oldBundleGemfile == "" {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		} else {
-			os.Setenv("BUNDLE_GEMFILE", oldBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", oldBundleGemfile)
 		}
 	}()
-	os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
+	_ = os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
 
 	// Generate lockfile
 	lockfilePath := testGemfilePath + ".lock"
@@ -58,12 +58,12 @@ gem 'rake'
 	oldGemHome := os.Getenv("GEM_HOME")
 	defer func() {
 		if oldGemHome == "" {
-			os.Unsetenv("GEM_HOME")
+			_ = os.Unsetenv("GEM_HOME")
 		} else {
-			os.Setenv("GEM_HOME", oldGemHome)
+			_ = os.Setenv("GEM_HOME", oldGemHome)
 		}
 	}()
-	os.Setenv("GEM_HOME", gemHomeDir)
+	_ = os.Setenv("GEM_HOME", gemHomeDir)
 
 	// Create fake gem directories to simulate installed gems
 	for _, spec := range parsed.GemSpecs {

--- a/cmd/ore/commands/clean.go
+++ b/cmd/ore/commands/clean.go
@@ -12,7 +12,8 @@ import (
 // RunClean implements the ore clean command
 func RunClean(args []string) error {
 	fs := flag.NewFlagSet("clean", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	vendorDir := fs.String("vendor", defaultVendorDir(), "Vendor directory")
 	dryRun := fs.Bool("dry-run", false, "Print what would be removed without actually removing")
 	verbose := fs.Bool("v", false, "Enable verbose output")
@@ -20,14 +21,30 @@ func RunClean(args []string) error {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(*gemfilePath)
+	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
 	if err != nil {
-		return fmt.Errorf("failed to find lockfile: %w", err)
+		// If findLockfilePath fails, we might just use the path as is if it exists
+		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
+			finalLockfilePath = effectiveLockfilePath
+		} else {
+			return fmt.Errorf("failed to find lockfile: %w", err)
+		}
 	}
 
 	// Parse lockfile to get gems that should be kept
-	lock, err := lockfile.ParseFile(lockfilePath)
+	lock, err := lockfile.ParseFile(finalLockfilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse lockfile: %w", err)
 	}

--- a/cmd/ore/commands/custom_gemfile_test.go
+++ b/cmd/ore/commands/custom_gemfile_test.go
@@ -28,12 +28,12 @@ gem 'rake'
 	oldEnv := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if oldEnv == "" {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		} else {
-			os.Setenv("BUNDLE_GEMFILE", oldEnv)
+			_ = os.Setenv("BUNDLE_GEMFILE", oldEnv)
 		}
 	}()
-	os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
+	_ = os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
 
 	// Generate lockfile
 	lockfilePath := testGemfilePath + ".lock"

--- a/cmd/ore/commands/customgemfile_test.go
+++ b/cmd/ore/commands/customgemfile_test.go
@@ -30,12 +30,12 @@ gem 'rake'
 	oldEnv := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if oldEnv == "" {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		} else {
-			os.Setenv("BUNDLE_GEMFILE", oldEnv)
+			_ = os.Setenv("BUNDLE_GEMFILE", oldEnv)
 		}
 	}()
-	os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
+	_ = os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
 
 	// The lockfile path that ore will use
 	lockfilePath := testGemfilePath + ".lock"

--- a/cmd/ore/commands/exec.go
+++ b/cmd/ore/commands/exec.go
@@ -12,10 +12,22 @@ import (
 // RunExec implements the ore exec command
 func RunExec(args []string, buildEnv func(vendorDir string, specs []lockfile.GemSpec) ([]string, error)) error {
 	fs := flag.NewFlagSet("exec", flag.ContinueOnError)
-	lockfilePath := fs.String("lockfile", defaultLockfilePath(), "Path to Gemfile.lock")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	vendorDir := fs.String("vendor", defaultVendorDir(), "Path to installed gems (created by ore install)")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
 	}
 
 	cmdArgs := fs.Args()
@@ -23,7 +35,7 @@ func RunExec(args []string, buildEnv func(vendorDir string, specs []lockfile.Gem
 		return fmt.Errorf("no command provided; usage: ore exec [options] -- <command> [args...]")
 	}
 
-	gems, err := loadGemSpecs(*lockfilePath)
+	gems, err := loadGemSpecs(effectiveLockfilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/ore/commands/gemfile_flag_test.go
+++ b/cmd/ore/commands/gemfile_flag_test.go
@@ -1,0 +1,229 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/contriboss/gemfile-go/lockfile"
+	"github.com/contriboss/ore-light/internal/extensions"
+)
+
+func TestGemfileFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a custom Gemfile in a subdirectory
+	customDir := filepath.Join(tmpDir, "custom")
+	if err := os.MkdirAll(customDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	gemfilePath := filepath.Join(customDir, "MyGemfile")
+	gemfileContent := "source 'https://rubygems.org'\ngem 'rake'\n"
+	if err := os.WriteFile(gemfilePath, []byte(gemfileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("InstallWithGemfileFlag", func(t *testing.T) {
+		// Mock callbacks for RunInstall
+		callbacks := InstallCallbacks{
+			GetDownloadManager: func(workers int) (DownloadManager, error) {
+				return &mockDownloadManager{cacheDir: t.TempDir()}, nil
+			},
+			GetDefaultVendorDir: func() string {
+				return filepath.Join(tmpDir, "vendor")
+			},
+			InstallFromCache: func(ctx context.Context, cacheDir, vendorDir string, gems []lockfile.GemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{Installed: len(gems)}, nil
+			},
+			InstallGitGems: func(ctx context.Context, vendorDir, rubyScope string, gitSpecs []lockfile.GitGemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{}, nil
+			},
+			InstallPathGems: func(ctx context.Context, vendorDir, rubyScope string, pathSpecs []lockfile.PathGemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{}, nil
+			},
+		}
+
+		// Run install with -gemfile flag
+		// It should automatically generate MyGemfile.lock
+		args := []string{"-gemfile", gemfilePath}
+		if err := RunInstall(args, callbacks); err != nil {
+			t.Fatalf("RunInstall failed: %v", err)
+		}
+
+		// Verify lockfile was created
+		lockfilePath := gemfilePath + ".lock"
+		if _, err := os.Stat(lockfilePath); os.IsNotExist(err) {
+			t.Errorf("Expected lockfile to be created at %s", lockfilePath)
+		}
+	})
+
+	t.Run("AddWithGemfileFlag", func(t *testing.T) {
+		// Run add with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "rspec"}
+		if err := RunAdd(args); err != nil {
+			t.Fatalf("RunAdd failed: %v", err)
+		}
+
+		// Verify Gemfile content
+		content, err := os.ReadFile(gemfilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(content), "rspec") {
+			t.Errorf("Expected MyGemfile to contain 'rspec', got:\n%s", string(content))
+		}
+	})
+
+	t.Run("RemoveWithGemfileFlag", func(t *testing.T) {
+		// Run remove with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "rake"}
+		if err := RunRemove(args); err != nil {
+			t.Fatalf("RunRemove failed: %v", err)
+		}
+
+		// Verify Gemfile content
+		content, err := os.ReadFile(gemfilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(content), "gem 'rake'") {
+			t.Errorf("Expected MyGemfile NOT to contain 'rake', got:\n%s", string(content))
+		}
+	})
+
+	t.Run("CheckWithGemfileFlag", func(t *testing.T) {
+		// Update lockfile to match Gemfile state after Add and Remove
+		// Gemfile should now contain 'rspec' and NOT 'rake'
+		if err := RunLock([]string{"-gemfile", gemfilePath}); err != nil {
+			t.Fatalf("RunLock failed: %v", err)
+		}
+
+		// Create a vendor directory with the expected structure
+		vendorDir := filepath.Join(tmpDir, "vendor_check")
+		gemsDir := filepath.Join(vendorDir, "gems")
+		if err := os.MkdirAll(gemsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Parse the newly created lockfile to see what versions were resolved
+		parsed, err := loadLockfile(gemfilePath + ".lock")
+		if err != nil {
+			t.Fatalf("failed to load lockfile: %v", err)
+		}
+
+		// Create dummy gem directories for all gems in the lockfile
+		for _, spec := range parsed.GemSpecs {
+			if err := os.MkdirAll(filepath.Join(gemsDir, spec.FullName()), 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Run check with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "-vendor", vendorDir}
+		if err := RunCheck(args); err != nil {
+			t.Fatalf("RunCheck failed: %v", err)
+		}
+	})
+
+	t.Run("ExecWithGemfileFlag", func(t *testing.T) {
+		// Mock buildEnv for RunExec
+		buildEnv := func(vendorDir string, specs []lockfile.GemSpec) ([]string, error) {
+			return os.Environ(), nil
+		}
+
+		// Run exec with -gemfile flag
+		// We use 'true' as the command because it exists on most systems and returns 0
+		args := []string{"-gemfile", gemfilePath, "--", "true"}
+		if err := RunExec(args, buildEnv); err != nil {
+			t.Fatalf("RunExec failed: %v", err)
+		}
+	})
+
+	t.Run("UpdateWithGemfileFlag", func(t *testing.T) {
+		// Run update with -gemfile flag
+		args := []string{"-gemfile", gemfilePath}
+		if err := RunUpdate(args); err != nil {
+			t.Fatalf("RunUpdate failed: %v", err)
+		}
+	})
+
+	t.Run("AuditWithGemfileFlag", func(t *testing.T) {
+		// Run audit with -gemfile flag
+		// Note: this will likely fail because advisory database is missing,
+		// but we want to check if it parses the flags and finds the lockfile
+		args := []string{"-gemfile", gemfilePath}
+		err := RunAudit(args)
+		if err == nil {
+			// Unexpected success? Maybe db exists in environment
+		} else if strings.Contains(err.Error(), "failed to parse lockfile") || strings.Contains(err.Error(), "failed to find lockfile") {
+			t.Fatalf("RunAudit failed to find/parse lockfile: %v", err)
+		}
+	})
+
+	t.Run("TreeWithGemfileFlag", func(t *testing.T) {
+		// Run tree with -gemfile flag
+		args := []string{"-gemfile", gemfilePath}
+		if err := RunTree(args); err != nil {
+			t.Fatalf("RunTree failed: %v", err)
+		}
+	})
+
+	t.Run("CleanWithGemfileFlag", func(t *testing.T) {
+		// Run clean with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "-dry-run"}
+		if err := RunClean(args); err != nil {
+			t.Fatalf("RunClean failed: %v", err)
+		}
+	})
+	t.Run("ShowWithGemfileFlag", func(t *testing.T) {
+		// Run show with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "--paths"}
+		if err := RunShow(args); err != nil {
+			t.Fatalf("RunShow failed: %v", err)
+		}
+	})
+
+	t.Run("WhyWithGemfileFlag", func(t *testing.T) {
+		// Run why with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "rspec"}
+		if err := RunWhy(args); err != nil {
+			t.Fatalf("RunWhy failed: %v", err)
+		}
+	})
+
+	t.Run("OutdatedWithGemfileFlag", func(t *testing.T) {
+		// Run outdated with -gemfile flag
+		args := []string{"-gemfile", gemfilePath, "--plain"}
+		// Note: LoadOutdatedGems might fail without actual network or registry mock,
+		// but we want to check flag parsing and lockfile derivation.
+		err := RunOutdated(args)
+		if err != nil && !strings.Contains(err.Error(), "failed to check") {
+			// If it fails because of something other than registry check, it might be a flag issue
+			t.Logf("RunOutdated failed (possibly expected): %v", err)
+		}
+	})
+
+	t.Run("PlatformWithGemfileFlag", func(t *testing.T) {
+		// Run platform with -gemfile flag
+		args := []string{"-gemfile", gemfilePath}
+		if err := RunPlatform(args); err != nil {
+			t.Fatalf("RunPlatform failed: %v", err)
+		}
+	})
+}
+
+// mockDownloadManager implements DownloadManager for testing
+type mockDownloadManager struct {
+	cacheDir string
+}
+
+func (m *mockDownloadManager) CheckSourceHealth(ctx context.Context) {}
+func (m *mockDownloadManager) DownloadAll(ctx context.Context, gems []lockfile.GemSpec, force bool) (DownloadReport, error) {
+	return DownloadReport{Skipped: len(gems)}, nil
+}
+func (m *mockDownloadManager) CacheDir() string {
+	return m.cacheDir
+}

--- a/cmd/ore/commands/install.go
+++ b/cmd/ore/commands/install.go
@@ -50,7 +50,8 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 	startTime := time.Now()
 
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
-	lockfilePath := fs.String("lockfile", defaultLockfilePath(), "Path to Gemfile.lock")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	workers := fs.Int("workers", defaultDownloadWorkers(), "Number of concurrent downloads")
 	force := fs.Bool("force", false, "Re-download or reinstall even if artifacts exist")
 	vendorDir := fs.String("vendor", callbacks.GetDefaultVendorDir(), "Destination directory for installed gems")
@@ -62,12 +63,23 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	quiet := quietOutput()
 
 	// Debug: show which lockfile we're using
 	if !quiet || os.Getenv("ORE_DEBUG") != "" {
 		fmt.Printf("DEBUG: BUNDLE_GEMFILE=%s\n", os.Getenv("BUNDLE_GEMFILE"))
-		fmt.Printf("DEBUG: Using lockfile: %s\n", *lockfilePath)
+		fmt.Printf("DEBUG: Using lockfile: %s\n", effectiveLockfilePath)
 	}
 
 	dm, err := callbacks.GetDownloadManager(*workers)
@@ -82,7 +94,7 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 	dm.CheckSourceHealth(ctx)
 
 	// Load both regular gems and git gems from lockfile
-	parsed, err := loadOrGenerateLockfile(*lockfilePath, quiet)
+	parsed, err := loadOrGenerateLockfile(effectiveLockfilePath, quiet)
 	if err != nil {
 		return err
 	}
@@ -117,12 +129,15 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 		}
 
 		// If filtering by groups, we need to load the Gemfile to get group information
-		gemfilePath := detectGemfileFromLock(*lockfilePath)
-		if gemfilePath == "" {
-			gemfilePath = "Gemfile"
+		effectiveGemfilePath := *gemfilePath
+		if effectiveGemfilePath == "" {
+			effectiveGemfilePath = detectGemfileFromLock(effectiveLockfilePath)
+		}
+		if effectiveGemfilePath == "" {
+			effectiveGemfilePath = "Gemfile"
 		}
 
-		if err := enrichGemsWithGroups(gemfilePath, parsed); err != nil {
+		if err := enrichGemsWithGroups(effectiveGemfilePath, parsed); err != nil {
 			if *verbose {
 				fmt.Fprintf(os.Stderr, "Warning: could not load Gemfile for group filtering: %v\n", err)
 				fmt.Fprintf(os.Stderr, "Proceeding without group filtering.\n")
@@ -249,11 +264,11 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 
 	// Only include --lockfile if non-default
 	defaultLock := defaultLockfilePath()
-	if *lockfilePath != defaultLock {
+	if effectiveLockfilePath != defaultLock {
 		// Simplify lockfile path
-		lockDisplay := *lockfilePath
+		lockDisplay := effectiveLockfilePath
 		if cwd, err := os.Getwd(); err == nil {
-			if rel, err := filepath.Rel(cwd, *lockfilePath); err == nil && !strings.HasPrefix(rel, "..") {
+			if rel, err := filepath.Rel(cwd, effectiveLockfilePath); err == nil && !strings.HasPrefix(rel, "..") {
 				lockDisplay = rel
 			}
 		}

--- a/cmd/ore/commands/lock.go
+++ b/cmd/ore/commands/lock.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 // RunLock implements the ore lock command
 func RunLock(args []string) error {
 	fs := flag.NewFlagSet("lock", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	verbose := fs.Bool("v", false, "Enable verbose output")
 	cpuProfile := fs.String("cpuprofile", "", "Write CPU profile to file")
 	allowPrerelease := fs.Bool("prerelease", false, "Allow prerelease versions")
@@ -27,6 +28,12 @@ func RunLock(args []string) error {
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Resolve effective Gemfile path
+	effectiveGemfilePath := *gemfilePath
+	if effectiveGemfilePath == "" {
+		effectiveGemfilePath = defaultGemfilePath()
 	}
 
 	// Enable CPU profiling if requested
@@ -46,18 +53,18 @@ func RunLock(args []string) error {
 		defer pprof.StopCPUProfile()
 	}
 
-	if _, err := os.Stat(*gemfilePath); err != nil {
-		return fmt.Errorf("gemfile not found at %s", *gemfilePath)
+	if _, err := os.Stat(effectiveGemfilePath); err != nil {
+		return fmt.Errorf("gemfile not found at %s", effectiveGemfilePath)
 	}
 
 	if *verbose {
-		fmt.Printf("Resolving dependencies from %s...\n", *gemfilePath)
+		fmt.Printf("Resolving dependencies from %s...\n", effectiveGemfilePath)
 	}
 
 	resolver.SetAllowPrereleases(*allowPrerelease)
 
 	startTime := time.Now()
-	if err := resolver.GenerateLockfileWithPlatforms(*gemfilePath, nil, platforms); err != nil {
+	if err := resolver.GenerateLockfileWithPlatforms(effectiveGemfilePath, nil, platforms); err != nil {
 		return fmt.Errorf("failed to generate lockfile: %w", err)
 	}
 	elapsed := time.Since(startTime)
@@ -66,7 +73,12 @@ func RunLock(args []string) error {
 		fmt.Printf("Resolution took: %v\n", elapsed)
 	}
 
-	lockfilePath := *gemfilePath + ".lock"
+	// Determine lockfile path for display
+	lockfilePath := effectiveGemfilePath + ".lock"
+	if filepath.Base(effectiveGemfilePath) == "gems.rb" {
+		lockfilePath = filepath.Join(filepath.Dir(effectiveGemfilePath), "gems.locked")
+	}
+
 	if *verbose {
 		fmt.Printf("Updated %s\n", lockfilePath)
 	} else {

--- a/cmd/ore/commands/outdated.go
+++ b/cmd/ore/commands/outdated.go
@@ -14,11 +14,17 @@ import (
 // Auto-detects TTY: shows TUI if interactive terminal, plain text if piped
 func RunOutdated(args []string) error {
 	fs := flag.NewFlagSet("outdated", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	plainText := fs.Bool("plain", false, "Force plain text output (no TUI)")
 	cpuProfile := fs.String("cpuprofile", "", "Write CPU profile to file")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Resolve effective Gemfile path
+	effectiveGemfilePath := *gemfilePath
+	if effectiveGemfilePath == "" {
+		effectiveGemfilePath = defaultGemfilePath()
 	}
 
 	// CPU profiling support
@@ -39,7 +45,7 @@ func RunOutdated(args []string) error {
 	stdinTTY := isatty.IsTerminal(os.Stdin.Fd())
 
 	if !*plainText && stdoutTTY && stdinTTY {
-		if err := RunOutdatedTUI(*gemfilePath); err == nil {
+		if err := RunOutdatedTUI(effectiveGemfilePath); err == nil {
 			return nil
 		} else {
 			logger.Warn("could not start interactive TUI, falling back to plain text output", "error", err)
@@ -51,7 +57,7 @@ func RunOutdated(args []string) error {
 	// Plain text output (for pipes, scripts, or --plain flag)
 	logger.Debug("checking for outdated gems...")
 
-	gems, err := LoadOutdatedGems(*gemfilePath)
+	gems, err := LoadOutdatedGems(effectiveGemfilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/ore/commands/platform.go
+++ b/cmd/ore/commands/platform.go
@@ -15,24 +15,27 @@ import (
 // RunPlatform implements the ore platform command
 func RunPlatform(args []string) error {
 	fs := flag.NewFlagSet("platform", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	rubyOnly := fs.Bool("ruby", false, "Display only Ruby version requirement")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(*gemfilePath)
-	if err != nil {
-		return fmt.Errorf("failed to find lockfile: %w", err)
+	// Resolve effective Gemfile path
+	effectiveGemfilePath := *gemfilePath
+	if effectiveGemfilePath == "" {
+		effectiveGemfilePath = defaultGemfilePath()
 	}
+
+	// Find the lockfile - supports both Gemfile.lock and gems.locked
+	lockfilePath, _ := findLockfilePath(effectiveGemfilePath)
 
 	// Get current platform
 	currentPlatform := detectCurrentPlatform()
 
 	if *rubyOnly {
 		// Just show Ruby requirement from Gemfile
-		parser := gemfile.NewGemfileParser(*gemfilePath)
+		parser := gemfile.NewGemfileParser(effectiveGemfilePath)
 		parsed, err := parser.Parse()
 		if err != nil {
 			return fmt.Errorf("failed to parse Gemfile: %w", err)
@@ -46,7 +49,7 @@ func RunPlatform(args []string) error {
 
 	// Parse Gemfile for Ruby requirement
 	var rubyRequirement string
-	parser := gemfile.NewGemfileParser(*gemfilePath)
+	parser := gemfile.NewGemfileParser(effectiveGemfilePath)
 	parsed, err := parser.Parse()
 	if err == nil && parsed.RubyVersion != "" {
 		rubyRequirement = parsed.RubyVersion

--- a/cmd/ore/commands/remove.go
+++ b/cmd/ore/commands/remove.go
@@ -11,6 +11,7 @@ import (
 // RunRemove implements the ore remove command
 func RunRemove(args []string) error {
 	fs := flag.NewFlagSet("remove", flag.ContinueOnError)
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	verbose := fs.Bool("v", false, "Enable verbose output")
 
 	if err := fs.Parse(args); err != nil {
@@ -23,19 +24,25 @@ func RunRemove(args []string) error {
 	}
 
 	// Find Gemfile
-	paths, err := lockfile.FindGemfiles()
-	if err != nil {
-		return fmt.Errorf("failed to find Gemfile: %w", err)
+	var gemfileToUse string
+	if *gemfilePath != "" {
+		gemfileToUse = *gemfilePath
+	} else {
+		paths, err := lockfile.FindGemfiles()
+		if err != nil {
+			return fmt.Errorf("failed to find Gemfile: %w", err)
+		}
+		gemfileToUse = paths.Gemfile
 	}
 
 	if *verbose {
-		fmt.Printf("🗑️  Removing gems from %s...\n", paths.GetGemfileName())
+		fmt.Printf("🗑️  Removing gems from %s...\n", gemfileToUse)
 	}
 
 	// Process each gem
 	for _, gemName := range gems {
 		// Remove gem from Gemfile using gemfile-go writer
-		if err := gemfile.RemoveGemFromFile(paths.Gemfile, gemName); err != nil {
+		if err := gemfile.RemoveGemFromFile(gemfileToUse, gemName); err != nil {
 			return fmt.Errorf("failed to remove gem %s: %w", gemName, err)
 		}
 

--- a/cmd/ore/commands/show.go
+++ b/cmd/ore/commands/show.go
@@ -12,21 +12,38 @@ import (
 // RunShow implements the ore show command
 func RunShow(args []string) error {
 	fs := flag.NewFlagSet("show", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	vendorDir := fs.String("vendor", defaultVendorDir(), "Vendor directory")
 	paths := fs.Bool("paths", false, "List all gem paths")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(*gemfilePath)
+	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
 	if err != nil {
-		return fmt.Errorf("failed to find lockfile: %w", err)
+		// If findLockfilePath fails, try to use effectiveLockfilePath directly if it exists
+		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
+			finalLockfilePath = effectiveLockfilePath
+		} else {
+			return fmt.Errorf("failed to find lockfile: %w", err)
+		}
 	}
 
 	// Parse lockfile
-	lock, err := lockfile.ParseFile(lockfilePath)
+	lock, err := lockfile.ParseFile(finalLockfilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse lockfile: %w", err)
 	}

--- a/cmd/ore/commands/tree.go
+++ b/cmd/ore/commands/tree.go
@@ -9,20 +9,35 @@ import (
 // RunTree implements the ore tree command
 func RunTree(args []string) error {
 	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
-	lockfilePath := fs.String("lockfile", defaultLockfilePath(), "Path to Gemfile.lock")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	parsed, err := loadLockfile(*lockfilePath)
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
+	parsed, err := loadLockfile(effectiveLockfilePath)
 	if err != nil {
 		return err
 	}
 
 	// Enrich with group information from Gemfile
-	gemfilePath := detectGemfileFromLock(*lockfilePath)
-	if gemfilePath != "" {
-		if err := enrichGemsWithGroups(gemfilePath, parsed); err != nil {
+	effectiveGemfilePath := *gemfilePath
+	if effectiveGemfilePath == "" {
+		effectiveGemfilePath = detectGemfileFromLock(effectiveLockfilePath)
+	}
+	if effectiveGemfilePath != "" {
+		if err := enrichGemsWithGroups(effectiveGemfilePath, parsed); err != nil {
 			// Non-fatal: continue without group info
 			fmt.Fprintf(os.Stderr, "Warning: could not read Gemfile groups: %v\n", err)
 		}

--- a/cmd/ore/commands/update.go
+++ b/cmd/ore/commands/update.go
@@ -11,22 +11,28 @@ import (
 // RunUpdate implements the ore update command
 func RunUpdate(args []string) error {
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	gemfilePath := fs.String("gemfile", defaultGemfilePath(), "Path to Gemfile")
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile")
 	verbose := fs.Bool("v", false, "Enable verbose output")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Resolve effective Gemfile path
+	effectiveGemfilePath := *gemfilePath
+	if effectiveGemfilePath == "" {
+		effectiveGemfilePath = defaultGemfilePath()
+	}
+
 	gems := fs.Args()
 
 	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(*gemfilePath)
+	lockfilePath, err := findLockfilePath(effectiveGemfilePath)
 	if err != nil {
 		return fmt.Errorf("failed to find lockfile: %w", err)
 	}
 
 	// Parse Gemfile to ensure it exists and is valid
-	parser := gemfile.NewGemfileParser(*gemfilePath)
+	parser := gemfile.NewGemfileParser(effectiveGemfilePath)
 	_, parseErr := parser.Parse()
 	if parseErr != nil {
 		return fmt.Errorf("failed to parse Gemfile: %w", parseErr)
@@ -49,7 +55,7 @@ func RunUpdate(args []string) error {
 	}
 
 	// Regenerate lockfile with version pins for selective update
-	if err := resolver.GenerateLockfileWithPins(*gemfilePath, versionPins); err != nil {
+	if err := resolver.GenerateLockfileWithPins(effectiveGemfilePath, versionPins); err != nil {
 		return fmt.Errorf("failed to update lockfile: %w", err)
 	}
 

--- a/cmd/ore/commands/why.go
+++ b/cmd/ore/commands/why.go
@@ -13,22 +13,35 @@ import (
 // RunWhy implements the ore why command
 func RunWhy(args []string) error {
 	fs := flag.NewFlagSet("why", flag.ContinueOnError)
+	gemfilePath := fs.String("gemfile", "", "Path to Gemfile (used to derive lockfile path)")
+	lockfilePath := fs.String("lockfile", "", "Path to Gemfile.lock")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Resolve effective lockfile path
+	effectiveLockfilePath := *lockfilePath
+	if effectiveLockfilePath == "" {
+		if *gemfilePath != "" {
+			// If -gemfile is provided, use it to derive lockfile path
+			effectiveLockfilePath = *gemfilePath + ".lock"
+		} else {
+			effectiveLockfilePath = defaultLockfilePath()
+		}
+	}
+
 	if len(fs.Args()) == 0 {
-		return fmt.Errorf("usage: ore why <gem>")
+		return fmt.Errorf("usage: ore why [options] <gem>")
 	}
 
 	gemName := fs.Args()[0]
-	return why(gemName)
+	return why(gemName, effectiveLockfilePath)
 }
 
 // why shows why a gem is in the bundle by displaying dependency chains
-func why(gemName string) error {
+func why(gemName string, lockfilePath string) error {
 	// Parse lockfile
-	lock, err := lockfile.ParseFile("Gemfile.lock")
+	lock, err := lockfile.ParseFile(lockfilePath)
 	if err != nil {
 		return fmt.Errorf("failed to parse Gemfile.lock: %w", err)
 	}

--- a/internal/config/lockfile_test.go
+++ b/internal/config/lockfile_test.go
@@ -27,12 +27,12 @@ func TestDefaultLockfilePathWithBundleGemfile(t *testing.T) {
 	oldEnv := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if oldEnv == "" {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		} else {
-			os.Setenv("BUNDLE_GEMFILE", oldEnv)
+			_ = os.Setenv("BUNDLE_GEMFILE", oldEnv)
 		}
 	}()
-	os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
+	_ = os.Setenv("BUNDLE_GEMFILE", testGemfilePath)
 
 	// Call DefaultLockfilePath - it should return TestGemfile.lock
 	// even though that file doesn't exist yet

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -36,9 +36,9 @@ func TestResolveGemfilePath_BundleGemfile(t *testing.T) {
 	originalBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if originalBundleGemfile != "" {
-			os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
 		} else {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		}
 	}()
 
@@ -87,11 +87,11 @@ func TestResolveGemfilePath_BundleGemfile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear env var first
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 
 			// Set test env var
 			if tt.bundleGemfile != "" {
-				os.Setenv("BUNDLE_GEMFILE", tt.bundleGemfile)
+				_ = os.Setenv("BUNDLE_GEMFILE", tt.bundleGemfile)
 			}
 
 			// Create config
@@ -132,15 +132,15 @@ func TestResolveGemfilePath_BundleGemfile_Regression(t *testing.T) {
 	originalBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if originalBundleGemfile != "" {
-			os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
 		} else {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		}
 	}()
 
 	// Simulate CI environment with Appraisal
 	// This is the exact scenario that was failing in tree_haver CI
-	os.Setenv("BUNDLE_GEMFILE", "Appraisal.root.gemfile")
+	_ = os.Setenv("BUNDLE_GEMFILE", "Appraisal.root.gemfile")
 
 	path, source, err := ResolveGemfilePath(nil)
 
@@ -176,9 +176,9 @@ func TestDefaultLockfilePath_BundleGemfile(t *testing.T) {
 	originalBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if originalBundleGemfile != "" {
-			os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
 		} else {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		}
 	}()
 
@@ -223,7 +223,7 @@ func TestDefaultLockfilePath_BundleGemfile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set BUNDLE_GEMFILE
-			os.Setenv("BUNDLE_GEMFILE", tt.bundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", tt.bundleGemfile)
 
 			// Call DefaultLockfilePath
 			lockfilePath := DefaultLockfilePath()
@@ -243,9 +243,9 @@ func TestResolveVendorDir_BundlePathGemHome(t *testing.T) {
 	originalBundlePath := os.Getenv("BUNDLE_PATH")
 	defer func() {
 		if originalBundlePath != "" {
-			os.Setenv("BUNDLE_PATH", originalBundlePath)
+			_ = os.Setenv("BUNDLE_PATH", originalBundlePath)
 		} else {
-			os.Unsetenv("BUNDLE_PATH")
+			_ = os.Unsetenv("BUNDLE_PATH")
 		}
 	}()
 
@@ -277,9 +277,9 @@ func TestResolveVendorDir_BundlePathGemsDir(t *testing.T) {
 	originalBundlePath := os.Getenv("BUNDLE_PATH")
 	defer func() {
 		if originalBundlePath != "" {
-			os.Setenv("BUNDLE_PATH", originalBundlePath)
+			_ = os.Setenv("BUNDLE_PATH", originalBundlePath)
 		} else {
-			os.Unsetenv("BUNDLE_PATH")
+			_ = os.Unsetenv("BUNDLE_PATH")
 		}
 	}()
 
@@ -311,9 +311,9 @@ func TestResolveVendorDir_BundlePathBaseDir(t *testing.T) {
 	originalBundlePath := os.Getenv("BUNDLE_PATH")
 	defer func() {
 		if originalBundlePath != "" {
-			os.Setenv("BUNDLE_PATH", originalBundlePath)
+			_ = os.Setenv("BUNDLE_PATH", originalBundlePath)
 		} else {
-			os.Unsetenv("BUNDLE_PATH")
+			_ = os.Unsetenv("BUNDLE_PATH")
 		}
 	}()
 
@@ -339,9 +339,9 @@ func TestResolveVendorDir_BundlePathBaseDir_NoRubyVersion(t *testing.T) {
 	originalBundlePath := os.Getenv("BUNDLE_PATH")
 	defer func() {
 		if originalBundlePath != "" {
-			os.Setenv("BUNDLE_PATH", originalBundlePath)
+			_ = os.Setenv("BUNDLE_PATH", originalBundlePath)
 		} else {
-			os.Unsetenv("BUNDLE_PATH")
+			_ = os.Unsetenv("BUNDLE_PATH")
 		}
 	}()
 
@@ -376,15 +376,15 @@ func TestDefaultLockfilePath_NoFallback_Regression(t *testing.T) {
 	originalBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if originalBundleGemfile != "" {
-			os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
 		} else {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		}
 	}()
 
 	// Simulate the EXACT scenario from tree_haver CI failure
 	// where BUNDLE_GEMFILE=Appraisal.root.gemfile but that lockfile doesn't exist
-	os.Setenv("BUNDLE_GEMFILE", "Appraisal.root.gemfile")
+	_ = os.Setenv("BUNDLE_GEMFILE", "Appraisal.root.gemfile")
 
 	lockfilePath := DefaultLockfilePath()
 
@@ -419,14 +419,14 @@ func TestDefaultLockfilePath_UnsetBundleGemfile(t *testing.T) {
 	originalBundleGemfile := os.Getenv("BUNDLE_GEMFILE")
 	defer func() {
 		if originalBundleGemfile != "" {
-			os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
+			_ = os.Setenv("BUNDLE_GEMFILE", originalBundleGemfile)
 		} else {
-			os.Unsetenv("BUNDLE_GEMFILE")
+			_ = os.Unsetenv("BUNDLE_GEMFILE")
 		}
 	}()
 
 	// Unset BUNDLE_GEMFILE to test default behavior
-	os.Unsetenv("BUNDLE_GEMFILE")
+	_ = os.Unsetenv("BUNDLE_GEMFILE")
 
 	lockfilePath := DefaultLockfilePath()
 

--- a/internal/geminstall/gemspec.go
+++ b/internal/geminstall/gemspec.go
@@ -637,9 +637,7 @@ func formatMap(v interface{}) string {
 			// Let's remove it for map values to match observed Bundler behavior.
 			// This might be risky if there are maps where values MUST be frozen,
 			// but gemspecs rarely use maps other than metadata.
-			if strings.HasSuffix(valStr, ".freeze") {
-				valStr = strings.TrimSuffix(valStr, ".freeze")
-			}
+			valStr = strings.TrimSuffix(valStr, ".freeze")
 			parts = append(parts, fmt.Sprintf("%s => %s", keyStr, valStr))
 		}
 	}
@@ -747,8 +745,6 @@ func writeDependencies(buf *bytes.Buffer, v interface{}) {
 		method := "add_runtime_dependency"
 		if strings.Contains(typeStr, "development") {
 			method = "add_development_dependency"
-		} else {
-			method = "add_runtime_dependency" // Bundler default output explicit? NO, it uses add_runtime_dependency
 		}
 		// Actually Bundler uses add_dependency for runtime?
 		// Diff showed:


### PR DESCRIPTION
across all relevant commands

- `install`
- `add`
- `remove`
- `update`
- `lock`
- `check`
- `outdated`
- `exec`
- `audit`
- `tree`
- `clean`
- `show`
- `platform`