### PR TITLE
feat: ⬆️ Support `gems.rb` => `gems.locked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased](https://github.com/contriboss/ore-light/compare/v0.24.0...HEAD)
+
+### Features
+
+* Centralized and hardened lockfile resolution logic into reusable helpers (`resolveLockfilePath`, `resolveLockfilePathWithDerivedFallback`).
+* Read-only commands now fail fast with a clear error if the required lockfile is missing.
+* Expanded and strengthened the regression test suite to cover `gems.rb` and `gems.locked` interactions with more robust assertions.
+
+### Bug Fixes
+
+* Fixed lockfile derivation logic to correctly support Bundler's `gems.rb` -> `gems.locked` convention across all commands.
+* Resolved issues where commands would incorrectly search for `gems.rb.lock` or `Gemfile.lock.lock`.
+* Tightened flag parsing and error handling in `outdated` command tests to prevent silent regression skips.
+
 ## [0.24.0](https://github.com/contriboss/ore-light/compare/v0.23.0...v0.24.0) (2026-02-08)
 
 

--- a/cmd/ore/commands/audit.go
+++ b/cmd/ore/commands/audit.go
@@ -26,14 +26,9 @@ func RunAudit(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
+	effectiveLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
+	if err != nil {
+		return err
 	}
 
 	// Load lockfile

--- a/cmd/ore/commands/check.go
+++ b/cmd/ore/commands/check.go
@@ -21,25 +21,9 @@ func RunCheck(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
-	}
-
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
+	finalLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
 	if err != nil {
-		// If findLockfilePath fails, try to use effectiveLockfilePath directly if it exists
-		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
-			finalLockfilePath = effectiveLockfilePath
-		} else {
-			return fmt.Errorf("failed to find lockfile: %w - run 'ore lock' first", err)
-		}
+		return err
 	}
 
 	// Parse lockfile

--- a/cmd/ore/commands/clean.go
+++ b/cmd/ore/commands/clean.go
@@ -22,25 +22,9 @@ func RunClean(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
-	}
-
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
+	finalLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
 	if err != nil {
-		// If findLockfilePath fails, we might just use the path as is if it exists
-		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
-			finalLockfilePath = effectiveLockfilePath
-		} else {
-			return fmt.Errorf("failed to find lockfile: %w", err)
-		}
+		return err
 	}
 
 	// Parse lockfile to get gems that should be kept

--- a/cmd/ore/commands/exec.go
+++ b/cmd/ore/commands/exec.go
@@ -20,14 +20,9 @@ func RunExec(args []string, buildEnv func(vendorDir string, specs []lockfile.Gem
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
+	effectiveLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
+	if err != nil {
+		return err
 	}
 
 	cmdArgs := fs.Args()

--- a/cmd/ore/commands/gemfile_flag_test.go
+++ b/cmd/ore/commands/gemfile_flag_test.go
@@ -200,9 +200,11 @@ func TestGemfileFlag(t *testing.T) {
 		// Note: LoadOutdatedGems might fail without actual network or registry mock,
 		// but we want to check flag parsing and lockfile derivation.
 		err := RunOutdated(args)
-		if err != nil && !strings.Contains(err.Error(), "failed to check") {
-			// If it fails because of something other than registry check, it might be a flag issue
-			t.Logf("RunOutdated failed (possibly expected): %v", err)
+		if err != nil {
+			// Require either success or an error that clearly comes from the version-check network path
+			if !strings.Contains(err.Error(), "failed to check") {
+				t.Fatalf("RunOutdated failed with unexpected error (likely lockfile/flag issue): %v", err)
+			}
 		}
 	})
 

--- a/cmd/ore/commands/gemfile_lockfile_repro_test.go
+++ b/cmd/ore/commands/gemfile_lockfile_repro_test.go
@@ -1,0 +1,142 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/contriboss/gemfile-go/lockfile"
+	"github.com/contriboss/ore-light/internal/extensions"
+)
+
+func TestGemsRbGemsLockedInteraction(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create gems.rb
+	gemfilePath := filepath.Join(tmpDir, "gems.rb")
+	gemfileContent := "source 'https://rubygems.org'\ngem 'rake'\n"
+	if err := os.WriteFile(gemfilePath, []byte(gemfileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Test 'install' with gems.rb
+	t.Run("InstallGemsRb", func(t *testing.T) {
+		callbacks := InstallCallbacks{
+			GetDownloadManager: func(workers int) (DownloadManager, error) {
+				return &mockDownloadManager{cacheDir: t.TempDir()}, nil
+			},
+			GetDefaultVendorDir: func() string {
+				return filepath.Join(tmpDir, "vendor")
+			},
+			InstallFromCache: func(ctx context.Context, cacheDir, vendorDir string, gems []lockfile.GemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{Installed: len(gems)}, nil
+			},
+			InstallGitGems: func(ctx context.Context, vendorDir, rubyScope string, gitSpecs []lockfile.GitGemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{}, nil
+			},
+			InstallPathGems: func(ctx context.Context, vendorDir, rubyScope string, pathSpecs []lockfile.PathGemSpec, force bool, buildExtensions bool, extConfig *extensions.BuildConfig) (InstallReport, error) {
+				return InstallReport{}, nil
+			},
+		}
+
+		// ore install -gemfile gems.rb
+		args := []string{"-gemfile", "gems.rb"}
+		if err := RunInstall(args, callbacks); err != nil {
+			t.Fatalf("RunInstall failed: %v", err)
+		}
+
+		// It should have created gems.locked, NOT gems.rb.lock
+		if _, err := os.Stat("gems.locked"); os.IsNotExist(err) {
+			t.Errorf("Expected gems.locked to be created")
+		}
+		if _, err := os.Stat("gems.rb.lock"); err == nil {
+			t.Errorf("gems.rb.lock should NOT have been created")
+		}
+	})
+
+	// 2. Test 'check' with gems.rb
+	t.Run("CheckGemsRb", func(t *testing.T) {
+		// Create a minimal vendor dir to avoid unrelated failures
+		vendorDir := filepath.Join(tmpDir, "vendor")
+		if err := os.MkdirAll(filepath.Join(vendorDir, "gems"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		// gems.locked exists from previous step
+		args := []string{"-gemfile", "gems.rb", "-vendor", vendorDir}
+		if err := RunCheck(args); err != nil {
+			// Check if the error is about a missing lockfile or wrong lockfile
+			if strings.Contains(err.Error(), "gems.rb.lock") {
+				t.Errorf("RunCheck tried to look for gems.rb.lock instead of gems.locked: %v", err)
+			}
+		}
+	})
+
+	// 3. Test 'exec' with gems.rb
+	t.Run("ExecGemsRb", func(t *testing.T) {
+		vendorDir := filepath.Join(tmpDir, "vendor")
+		buildEnv := func(vDir string, specs []lockfile.GemSpec) ([]string, error) {
+			return os.Environ(), nil
+		}
+		args := []string{"-gemfile", "gems.rb", "-vendor", vendorDir, "--", "true"}
+		if err := RunExec(args, buildEnv); err != nil {
+			if strings.Contains(err.Error(), "gems.rb.lock") {
+				t.Errorf("RunExec tried to look for gems.rb.lock instead of gems.locked: %v", err)
+			} else {
+				t.Fatalf("RunExec failed: %v", err)
+			}
+		}
+	})
+
+	// 4. Test 'show' with gems.rb
+	t.Run("ShowGemsRb", func(t *testing.T) {
+		vendorDir := filepath.Join(tmpDir, "vendor")
+		args := []string{"-gemfile", "gems.rb", "-vendor", vendorDir, "rake"}
+		err := RunShow(args)
+		// We expect "gem rake is in lockfile but not installed" or success, NOT "failed to find lockfile"
+		if err != nil && (strings.Contains(err.Error(), "gems.rb.lock") || strings.Contains(err.Error(), "gems.rb.lock.lock")) {
+			t.Errorf("RunShow tried to look for wrong lockfile: %v", err)
+		}
+	})
+
+	// 5. Test 'why' with gems.rb
+	t.Run("WhyGemsRb", func(t *testing.T) {
+		args := []string{"-gemfile", "gems.rb", "rake"}
+		if err := RunWhy(args); err != nil {
+			t.Fatalf("RunWhy failed: %v", err)
+		}
+	})
+
+	// 6. Test 'tree' with gems.rb
+	t.Run("TreeGemsRb", func(t *testing.T) {
+		args := []string{"-gemfile", "gems.rb"}
+		if err := RunTree(args); err != nil {
+			t.Fatalf("RunTree failed: %v", err)
+		}
+	})
+
+	// 7. Test 'audit' with gems.rb
+	t.Run("AuditGemsRb", func(t *testing.T) {
+		args := []string{"-gemfile", "gems.rb"}
+		err := RunAudit(args)
+		// Advisory DB might be missing, that's fine.
+		// We want to ensure it doesn't fail with "failed to parse lockfile" due to wrong path.
+		if err != nil && strings.Contains(err.Error(), "gems.rb.lock") {
+			t.Fatalf("RunAudit failed with wrong lockfile path: %v", err)
+		}
+	})
+
+	// 8. Test 'clean' with gems.rb
+	t.Run("CleanGemsRb", func(t *testing.T) {
+		args := []string{"-gemfile", "gems.rb", "-dry-run"}
+		if err := RunClean(args); err != nil {
+			t.Fatalf("RunClean failed: %v", err)
+		}
+	})
+}

--- a/cmd/ore/commands/helpers.go
+++ b/cmd/ore/commands/helpers.go
@@ -117,6 +117,66 @@ func defaultLockfilePath() string {
 	return config.DefaultLockfilePath()
 }
 
+// deriveLockfilePathFromGemfile derives the lockfile path from a Gemfile path
+// without checking if it exists.
+func deriveLockfilePathFromGemfile(gemfilePath string) string {
+	dir := filepath.Dir(gemfilePath)
+	base := filepath.Base(gemfilePath)
+
+	if base == "gems.rb" {
+		return filepath.Join(dir, "gems.locked")
+	}
+	return gemfilePath + ".lock"
+}
+
+// resolveLockfilePath determines the lockfile path based on flags and defaults.
+// It prioritizes the explicit lockfile flag, then derives it from the gemfile flag,
+// and finally falls back to the default lockfile path.
+// If the lockfile does not exist, it returns an error.
+func resolveLockfilePath(gemfileFlag, lockfileFlag string) (string, error) {
+	if lockfileFlag != "" {
+		if _, err := os.Stat(lockfileFlag); err != nil {
+			return "", fmt.Errorf("lockfile not found: %s", lockfileFlag)
+		}
+		return lockfileFlag, nil
+	}
+
+	var path string
+	if gemfileFlag != "" {
+		var err error
+		path, err = findLockfilePath(gemfileFlag)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		path = defaultLockfilePath()
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("default lockfile not found (tried %s)", path)
+		}
+	}
+
+	return path, nil
+}
+
+// resolveLockfilePathWithDerivedFallback is like resolveLockfilePath but if the
+// lockfile doesn't exist, it returns the derived path instead of an error.
+// This is useful for commands like 'install' or 'update' that can generate the lockfile.
+func resolveLockfilePathWithDerivedFallback(gemfileFlag, lockfileFlag string) string {
+	if lockfileFlag != "" {
+		return lockfileFlag
+	}
+
+	if gemfileFlag != "" {
+		path, err := findLockfilePath(gemfileFlag)
+		if err == nil {
+			return path
+		}
+		return deriveLockfilePathFromGemfile(gemfileFlag)
+	}
+
+	return defaultLockfilePath()
+}
+
 // loadLockfile loads and parses a lockfile
 func loadLockfile(lockfilePath string) (*lockfile.Lockfile, error) {
 	file, err := os.Open(lockfilePath)

--- a/cmd/ore/commands/install.go
+++ b/cmd/ore/commands/install.go
@@ -64,15 +64,7 @@ func RunInstall(args []string, callbacks InstallCallbacks) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
-	}
+	effectiveLockfilePath := resolveLockfilePathWithDerivedFallback(*gemfilePath, *lockfilePath)
 
 	quiet := quietOutput()
 

--- a/cmd/ore/commands/lock.go
+++ b/cmd/ore/commands/lock.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime/pprof"
 	"time"
 
@@ -74,10 +73,7 @@ func RunLock(args []string) error {
 	}
 
 	// Determine lockfile path for display
-	lockfilePath := effectiveGemfilePath + ".lock"
-	if filepath.Base(effectiveGemfilePath) == "gems.rb" {
-		lockfilePath = filepath.Join(filepath.Dir(effectiveGemfilePath), "gems.locked")
-	}
+	lockfilePath := deriveLockfilePathFromGemfile(effectiveGemfilePath)
 
 	if *verbose {
 		fmt.Printf("Updated %s\n", lockfilePath)

--- a/cmd/ore/commands/platform.go
+++ b/cmd/ore/commands/platform.go
@@ -27,8 +27,8 @@ func RunPlatform(args []string) error {
 		effectiveGemfilePath = defaultGemfilePath()
 	}
 
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, _ := findLockfilePath(effectiveGemfilePath)
+	// Resolve effective lockfile path
+	lockfilePath, _ := resolveLockfilePath(effectiveGemfilePath, "")
 
 	// Get current platform
 	currentPlatform := detectCurrentPlatform()

--- a/cmd/ore/commands/show.go
+++ b/cmd/ore/commands/show.go
@@ -21,25 +21,9 @@ func RunShow(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
-	}
-
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	finalLockfilePath, err := findLockfilePath(effectiveLockfilePath)
+	finalLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
 	if err != nil {
-		// If findLockfilePath fails, try to use effectiveLockfilePath directly if it exists
-		if _, serr := os.Stat(effectiveLockfilePath); serr == nil {
-			finalLockfilePath = effectiveLockfilePath
-		} else {
-			return fmt.Errorf("failed to find lockfile: %w", err)
-		}
+		return err
 	}
 
 	// Parse lockfile

--- a/cmd/ore/commands/tree.go
+++ b/cmd/ore/commands/tree.go
@@ -16,14 +16,9 @@ func RunTree(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
+	effectiveLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
+	if err != nil {
+		return err
 	}
 
 	parsed, err := loadLockfile(effectiveLockfilePath)

--- a/cmd/ore/commands/update.go
+++ b/cmd/ore/commands/update.go
@@ -25,11 +25,8 @@ func RunUpdate(args []string) error {
 
 	gems := fs.Args()
 
-	// Find the lockfile - supports both Gemfile.lock and gems.locked
-	lockfilePath, err := findLockfilePath(effectiveGemfilePath)
-	if err != nil {
-		return fmt.Errorf("failed to find lockfile: %w", err)
-	}
+	// Resolve effective lockfile path
+	lockfilePath := resolveLockfilePathWithDerivedFallback(effectiveGemfilePath, "")
 
 	// Parse Gemfile to ensure it exists and is valid
 	parser := gemfile.NewGemfileParser(effectiveGemfilePath)

--- a/cmd/ore/commands/why.go
+++ b/cmd/ore/commands/why.go
@@ -20,14 +20,9 @@ func RunWhy(args []string) error {
 	}
 
 	// Resolve effective lockfile path
-	effectiveLockfilePath := *lockfilePath
-	if effectiveLockfilePath == "" {
-		if *gemfilePath != "" {
-			// If -gemfile is provided, use it to derive lockfile path
-			effectiveLockfilePath = *gemfilePath + ".lock"
-		} else {
-			effectiveLockfilePath = defaultLockfilePath()
-		}
+	effectiveLockfilePath, err := resolveLockfilePath(*gemfilePath, *lockfilePath)
+	if err != nil {
+		return err
 	}
 
 	if len(fs.Args()) == 0 {


### PR DESCRIPTION
* Centralized and hardened lockfile resolution logic into reusable helpers (`resolveLockfilePath`, `resolveLockfilePathWithDerivedFallback`).
* Read-only commands now fail fast with a clear error if the required lockfile is missing.
* Expanded and strengthened the regression test suite to cover `gems.rb` and `gems.locked` interactions with more robust assertions.
* Fixed lockfile derivation logic to correctly support Bundler's `gems.rb` -> `gems.locked` convention across all commands.
* Resolved issues where commands would incorrectly search for `gems.rb.lock` or `Gemfile.lock.lock`.
* Tightened flag parsing and error handling in `outdated` command tests to prevent silent regression skips.